### PR TITLE
Removed unused constant eZContentStagingEvent::ACTION_INITIALIZEFEED

### DIFF
--- a/classes/ezcontentstagingevent.php
+++ b/classes/ezcontentstagingevent.php
@@ -54,7 +54,6 @@ class eZContentStagingEvent extends eZPersistentObject
         self::ACTION_UPDATEOBJECSTATE => 'content state changed',
         self::ACTION_UPDATEPRIORITY => 'child priority changed',
         self::ACTION_UPDATESECTION => 'section changed',
-        self::ACTION_INITIALIZEFEED => 'node initialization',
         self::ACTION_RESTOREFROMTRASH => 'object restored from trash',
     );
 


### PR DESCRIPTION
Hi,

Could you pull my change, which fix the PHP fatal error. This is a fix for error:
`Fatal error: Undefined class constant 'self::ACTION_INITIALIZEFEED'` in _eZContentStagingEvent_ class.

That constant is not used in the extension.
